### PR TITLE
Added util function getSovereignAccountAddresses

### DIFF
--- a/.changeset/tender-apes-build.md
+++ b/.changeset/tender-apes-build.md
@@ -1,0 +1,5 @@
+---
+'@moonbeam-network/xcm-utils': patch
+---
+
+Added util function getSovereignAccountAddresses

--- a/package-lock.json
+++ b/package-lock.json
@@ -17351,7 +17351,8 @@
       },
       "peerDependencies": {
         "@polkadot/api": "^10.10.1",
-        "@polkadot/apps-config": "^0.132.1"
+        "@polkadot/apps-config": "^0.132.1",
+        "@polkadot/util": "^12.5.1"
       }
     },
     "packages/utils/node_modules/lru-cache": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -59,6 +59,7 @@
   },
   "peerDependencies": {
     "@polkadot/api": "^10.10.1",
-    "@polkadot/apps-config": "^0.132.1"
+    "@polkadot/apps-config": "^0.132.1",
+    "@polkadot/util": "^12.5.1"
   }
 }

--- a/packages/utils/src/polkadot/index.ts
+++ b/packages/utils/src/polkadot/index.ts
@@ -1,1 +1,2 @@
 export * from './polkadot.api';
+export * from './polkadot.address';

--- a/packages/utils/src/polkadot/polkadot.address.test.ts
+++ b/packages/utils/src/polkadot/polkadot.address.test.ts
@@ -1,0 +1,25 @@
+import { getSovereignAccountAddresses } from './polkadot.address';
+
+describe('utils - polkadot address', () => {
+  describe('getSovereignAccountAddresses', () => {
+    it('should get correct addresses for paraId 1000', async () => {
+      expect(getSovereignAccountAddresses(1000)).toStrictEqual({
+        generic:
+          '0x7369626ce8030000000000000000000000000000000000000000000000000000',
+        moonbeam: '0x7369626ce8030000000000000000000000000000',
+        relay:
+          '0x70617261e8030000000000000000000000000000000000000000000000000000',
+      });
+    });
+
+    it('should get correct addresses for paraId 3019', async () => {
+      expect(getSovereignAccountAddresses(3019)).toStrictEqual({
+        generic:
+          '0x7369626ccb0b0000000000000000000000000000000000000000000000000000',
+        moonbeam: '0x7369626ccb0b0000000000000000000000000000',
+        relay:
+          '0x70617261cb0b0000000000000000000000000000000000000000000000000000',
+      });
+    });
+  });
+});

--- a/packages/utils/src/polkadot/polkadot.address.ts
+++ b/packages/utils/src/polkadot/polkadot.address.ts
@@ -1,0 +1,18 @@
+import { bnToU8a, u8aToHex, stringToU8a } from '@polkadot/util';
+
+export function getSovereignAccountAddresses(paraId: number) {
+  const paraIdU8a = bnToU8a(paraId, { bitLength: 32 });
+  const relay = u8aToHex(
+    new Uint8Array([...stringToU8a('para'), ...paraIdU8a]),
+  ).padEnd(66, '0');
+  const generic = u8aToHex(
+    new Uint8Array([...stringToU8a('sibl'), ...paraIdU8a]),
+  ).padEnd(66, '0');
+  const moonbeam = generic.slice(0, 42);
+
+  return {
+    generic,
+    moonbeam,
+    relay,
+  };
+}


### PR DESCRIPTION
### Description

Basically, I implemented what we have here https://docs.moonbeam.network/builders/interoperability/xcm/xc-registration/xc-integration/ but without using `api`. The script itself is here: https://github.com/Moonsong-Labs/xcm-tools/blob/main/scripts/calculate-sovereign-account.ts.

### Checklist

- [x] If this requires a documentation change, I have created a PR in [moonbeam-docs](https://github.com/moonbeam-foundation/moonbeam-docs) repository.
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
