### PR TITLE
Handle unexpected endpoint closures in script

### DIFF
--- a/.changeset/early-cobras-whisper.md
+++ b/.changeset/early-cobras-whisper.md
@@ -1,0 +1,5 @@
+---
+'@moonbeam-network/xcm-config': patch
+---
+
+Remove duplicated nodle endpoint

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -1305,7 +1305,6 @@ export const nodle = new Parachain({
   ss58Format: 37,
   ws: [
     'wss://nodle-rpc.dwellir.com',
-    'wss://nodle-rpc.dwellir.com',
     'wss://nodle-parachain.api.onfinality.io/public-ws',
   ],
 });


### PR DESCRIPTION
### Description

We had some unexpected endpoint closures that we were not handling in the endpoint monitoring script, which resulted in a stop in the exectution, like in this one: https://github.com/moonbeam-foundation/xcm-sdk/actions/runs/10008210142/job/27664427373#step:8:70

In this PR I consider those closures as failing endpoints

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
