### PR TITLE
Adjust BTC fees

### DIFF
--- a/.changeset/silly-turtles-reply.md
+++ b/.changeset/silly-turtles-reply.md
@@ -1,0 +1,5 @@
+---
+'@moonbeam-network/xcm-config': patch
+---
+
+Adjust kbtc and ibtc fees

--- a/packages/config/src/configs/moonbeam.ts
+++ b/packages/config/src/configs/moonbeam.ts
@@ -274,7 +274,7 @@ export const moonbeamConfig = new ChainConfig({
       contract: ContractBuilder().Xtokens().transfer(),
       destination: interlay,
       destinationFee: {
-        amount: 0.0002476,
+        amount: 0.00000064,
         asset: ibtc,
         balance: BalanceBuilder().substrate().assets().account(),
       },

--- a/packages/config/src/configs/moonriver.ts
+++ b/packages/config/src/configs/moonriver.ts
@@ -230,7 +230,7 @@ export const moonriverConfig = new ChainConfig({
       contract: ContractBuilder().Xtokens().transfer(),
       destination: kintsugi,
       destinationFee: {
-        amount: 0.00000428,
+        amount: 0.0000011,
         asset: kbtc,
         balance: BalanceBuilder().substrate().assets().account(),
       },


### PR DESCRIPTION
### Description

- Adjust fees for iBTC and kBTC because the estimated ones are too high, preventing users with low balances from sending because of the amount check

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
