### PR TITLE
Change relay chains configuration

### DIFF
--- a/.changeset/orange-lemons-prove.md
+++ b/.changeset/orange-lemons-prove.md
@@ -1,0 +1,6 @@
+---
+'@moonbeam-network/xcm-builder': patch
+'@moonbeam-network/xcm-config': patch
+---
+
+Add transferAssetsUsingTypeAndThen function to xcmPallet and implement it to relay chains

--- a/packages/builder/src/extrinsic/ExtrinsicBuilder.interfaces.ts
+++ b/packages/builder/src/extrinsic/ExtrinsicBuilder.interfaces.ts
@@ -20,6 +20,7 @@ export enum XcmVersion {
   v1 = 'V1',
   v2 = 'V2',
   v3 = 'V3',
+  v4 = 'V4',
 }
 
 export type Parents = 0 | 1;

--- a/packages/builder/src/extrinsic/pallets/xcmPallet/xcmPallet.ts
+++ b/packages/builder/src/extrinsic/pallets/xcmPallet/xcmPallet.ts
@@ -2,7 +2,9 @@
 import {
   ExtrinsicConfigBuilder,
   Parents,
+  XcmVersion,
 } from '../../ExtrinsicBuilder.interfaces';
+import { getExtrinsicAccount } from '../../ExtrinsicBuilder.utils';
 import { ExtrinsicConfig } from '../../ExtrinsicConfig';
 import { getPolkadotXcmExtrinsicArgs } from '../polkadotXcm/polkadotXcm.util';
 
@@ -38,6 +40,75 @@ export function xcmPallet() {
                     },
                   ],
                 }),
+            }),
+        }),
+      };
+    },
+    transferAssetsUsingTypeAndThen: () => {
+      const func = 'transferAssetsUsingTypeAndThen';
+
+      return {
+        here: (): ExtrinsicConfigBuilder => ({
+          build: (params) =>
+            new ExtrinsicConfig({
+              module: pallet,
+              func,
+              getArgs: () => {
+                const version = XcmVersion.v4;
+                return [
+                  {
+                    [version]: {
+                      parents: 0,
+                      interior: {
+                        X1: [
+                          {
+                            Parachain: params.destination.parachainId,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    [version]: [
+                      {
+                        id: {
+                          parents: 0,
+                          interior: 'Here',
+                        },
+                        fun: {
+                          Fungible: params.amount,
+                        },
+                      },
+                    ],
+                  },
+                  'LocalReserve',
+                  {
+                    [version]: {
+                      parents: 0,
+                      interior: 'Here',
+                    },
+                  },
+                  'LocalReserve',
+                  {
+                    [version]: [
+                      {
+                        DepositAsset: {
+                          assets: {
+                            Wild: { AllCounted: 1 },
+                          },
+                          beneficiary: {
+                            parents: 0,
+                            interior: {
+                              X1: [getExtrinsicAccount(params.address)],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  'Unlimited',
+                ];
+              },
             }),
         }),
       };

--- a/packages/config/src/configs/alphanetRelay.ts
+++ b/packages/config/src/configs/alphanetRelay.ts
@@ -21,7 +21,7 @@ export const alphanetRelayConfig = new ChainConfig({
       },
       extrinsic: ExtrinsicBuilder()
         .xcmPallet()
-        .limitedReserveTransferAssets(0)
+        .transferAssetsUsingTypeAndThen()
         .here(),
     }),
   ],

--- a/packages/config/src/configs/kusama.ts
+++ b/packages/config/src/configs/kusama.ts
@@ -21,7 +21,7 @@ export const kusamaConfig = new ChainConfig({
       },
       extrinsic: ExtrinsicBuilder()
         .xcmPallet()
-        .limitedReserveTransferAssets(0)
+        .transferAssetsUsingTypeAndThen()
         .here(),
       fee: {
         asset: ksm,

--- a/packages/config/src/configs/polkadot.ts
+++ b/packages/config/src/configs/polkadot.ts
@@ -21,7 +21,7 @@ export const polkadotConfig = new ChainConfig({
       },
       extrinsic: ExtrinsicBuilder()
         .xcmPallet()
-        .limitedReserveTransferAssets(0)
+        .transferAssetsUsingTypeAndThen()
         .here(),
       fee: {
         asset: dot,


### PR DESCRIPTION
### Description

Change relay chain configurations to apply `transferAssetsUsingTypeAndThen` function insted of the filtered `limitedReserveTransferAssets`

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
