### PR TITLE
Add changeset for xcm-utils

### DIFF
--- a/.changeset/clean-papayas-grow.md
+++ b/.changeset/clean-papayas-grow.md
@@ -1,0 +1,5 @@
+---
+'@moonbeam-network/xcm-utils': minor
+---
+
+Release minor version for xcm-utils with isHexString


### PR DESCRIPTION
### Description

In the previous [PR](https://github.com/moonbeam-foundation/xcm-sdk/pull/351) I forgot to modify the changeset to include the xcm-utils version, because the `isHexString` was mover to xcm-utils later

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
