### PR TITLE
Fix asset ordering in fee calculation for assets in Asset Hub

### DIFF
--- a/.changeset/serious-ants-shout.md
+++ b/.changeset/serious-ants-shout.md
@@ -1,0 +1,5 @@
+---
+'@moonbeam-network/xcm-config': patch
+---
+
+Fix Asset Hub memecoins asset ordering in fee calculation

--- a/packages/config/src/configs/polkadotAssetHub.ts
+++ b/packages/config/src/configs/polkadotAssetHub.ts
@@ -62,9 +62,10 @@ export const polkadotAssetHubConfig = new ChainConfig({
       balance: BalanceBuilder().substrate().assets().account(),
       destination: moonbeam,
       destinationFee: {
-        amount: FeeBuilder()
-          .xcmPaymentApi()
-          .xcmPaymentFee({ isAssetReserveChain: false }),
+        amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
+          isAssetReserveChain: false,
+          shouldTransferAssetPrecedeAsset: true,
+        }),
         asset: usdt,
         balance: BalanceBuilder().substrate().assets().account(),
       },
@@ -84,9 +85,10 @@ export const polkadotAssetHubConfig = new ChainConfig({
       balance: BalanceBuilder().substrate().assets().account(),
       destination: moonbeam,
       destinationFee: {
-        amount: FeeBuilder()
-          .xcmPaymentApi()
-          .xcmPaymentFee({ isAssetReserveChain: false }),
+        amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
+          isAssetReserveChain: false,
+          shouldTransferAssetPrecedeAsset: true,
+        }),
         asset: usdt,
         balance: BalanceBuilder().substrate().assets().account(),
       },
@@ -128,9 +130,10 @@ export const polkadotAssetHubConfig = new ChainConfig({
       balance: BalanceBuilder().substrate().assets().account(),
       destination: moonbeam,
       destinationFee: {
-        amount: FeeBuilder()
-          .xcmPaymentApi()
-          .xcmPaymentFee({ isAssetReserveChain: false }),
+        amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
+          isAssetReserveChain: false,
+          shouldTransferAssetPrecedeAsset: true,
+        }),
         asset: usdt,
         balance: BalanceBuilder().substrate().assets().account(),
       },
@@ -150,9 +153,10 @@ export const polkadotAssetHubConfig = new ChainConfig({
       balance: BalanceBuilder().substrate().assets().account(),
       destination: moonbeam,
       destinationFee: {
-        amount: FeeBuilder()
-          .xcmPaymentApi()
-          .xcmPaymentFee({ isAssetReserveChain: false }),
+        amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
+          isAssetReserveChain: false,
+          shouldTransferAssetPrecedeAsset: true,
+        }),
         asset: usdt,
         balance: BalanceBuilder().substrate().assets().account(),
       },


### PR DESCRIPTION
### Description

Apply correct asset ordering in Fee calculations for PINK, DED, NCTR and WIFD

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
