### PR TITLE
Implement option to only send remote execution in MRL

### DIFF
--- a/packages/builder/src/mrl/MrlBuilder.interfaces.ts
+++ b/packages/builder/src/mrl/MrlBuilder.interfaces.ts
@@ -26,6 +26,7 @@ export interface MrlBuilderParams extends BuilderParams<AnyChain> {
   moonAsset: ChainAsset;
   moonChain: EvmParachain;
   moonGasLimit?: bigint;
+  sendOnlyRemoteExecution?: boolean;
   transact?: Transact;
 }
 

--- a/packages/builder/src/mrl/providers/wormhole/extrinsic/polkadotXcm/polkadotXcm.ts
+++ b/packages/builder/src/mrl/providers/wormhole/extrinsic/polkadotXcm/polkadotXcm.ts
@@ -30,6 +30,7 @@ export function polkadotXcm() {
         moonAsset,
         moonChain,
         moonApi,
+        sendOnlyRemoteExecution,
         source,
         sourceAddress,
         sourceApi,
@@ -85,11 +86,14 @@ export function polkadotXcm() {
           transact,
         });
 
-        // TODO add here ability to only send the remote execution (only `send`)
+        const transactionsToSend = sendOnlyRemoteExecution
+          ? [send]
+          : [...assetTransferTxs, send];
+
         return new ExtrinsicConfig({
           module: 'utility',
           func: 'batchAll',
-          getArgs: () => [[...assetTransferTxs, send]],
+          getArgs: () => [transactionsToSend],
         });
       },
     }),

--- a/packages/mrl/src/getTransferData/getTransferData.ts
+++ b/packages/mrl/src/getTransferData/getTransferData.ts
@@ -110,6 +110,7 @@ export async function getTransferData({
       isAutomatic,
       { evmSigner, polkadotSigner }: Partial<Signers>,
       statusCallback,
+      sendOnlyRemoteExecution,
     ): Promise<string[]> {
       const source = route.source.chain;
 
@@ -130,6 +131,7 @@ export async function getTransferData({
         feeAsset,
         isAutomatic,
         route,
+        sendOnlyRemoteExecution,
         sourceAddress,
       });
 

--- a/packages/mrl/src/getTransferData/getTransferData.utils.ts
+++ b/packages/mrl/src/getTransferData/getTransferData.utils.ts
@@ -102,6 +102,7 @@ export interface BuildTransferParams {
   feeAsset: AssetAmount;
   isAutomatic: boolean;
   route: AssetRoute;
+  sendOnlyRemoteExecution?: boolean;
   sourceAddress: string;
 }
 
@@ -133,6 +134,7 @@ export async function getMrlBuilderParams({
   feeAsset,
   isAutomatic,
   route,
+  sendOnlyRemoteExecution,
   sourceAddress,
 }: BuildTransferParams): Promise<MrlBuilderParams> {
   if (!route.mrl) {
@@ -162,6 +164,7 @@ export async function getMrlBuilderParams({
     moonApi,
     moonAsset: moonChain.nativeAsset,
     moonChain,
+    sendOnlyRemoteExecution,
     source,
     sourceAddress,
     sourceApi,

--- a/packages/mrl/src/mrl.interfaces.ts
+++ b/packages/mrl/src/mrl.interfaces.ts
@@ -26,6 +26,7 @@ export interface TransferData {
     isAutomatic: boolean,
     signers: Signers,
     statusCallback?: (params: ISubmittableResult) => void,
+    sendOnlyRemoteExecution?: boolean,
   ): Promise<string[]>;
 }
 


### PR DESCRIPTION
- When a parameter is passed, transactions with Parachains as source can only send the remote execution TX to the moonchain instead of sending the Assets Transfer TX + Remote Execution TX. This is helpful when a full transaction failed and the user has funds stuck in the computed origin account in the Moon Chain

