### PR TITLE
add DOT as feeAsset in config for Moonbeam to AssetHub

### DIFF
--- a/packages/builder/src/extrinsic/pallets/polkadotXcm/__snapshots__/polkadotXcm.test.ts.snap
+++ b/packages/builder/src/extrinsic/pallets/polkadotXcm/__snapshots__/polkadotXcm.test.ts.snap
@@ -455,6 +455,132 @@ exports[`polkadotXcm > limitedReserveWithdrawAssets > x2 > should get correct ar
 ]
 `;
 
+exports[`polkadotXcm > transferAssets > X2AndFeeHere > should be correct config 1`] = `
+ExtrinsicConfig {
+  "func": "transferAssets",
+  "getArgs": [Function],
+  "module": "polkadotXcm",
+}
+`;
+
+exports[`polkadotXcm > transferAssets > X2AndFeeHere > should get correct arguments 1`] = `
+[
+  {
+    "V1": {
+      "interior": {
+        "X1": {
+          "Parachain": 2032,
+        },
+      },
+      "parents": 1,
+    },
+  },
+  {
+    "V1": {
+      "interior": {
+        "X1": {
+          "AccountId32": {
+            "id": "0x18e6c7ad45fbab18778710642072fdd057470b76d4d568b44dea6accd5b0c423",
+            "network": null,
+          },
+        },
+      },
+      "parents": 0,
+    },
+  },
+  {
+    "V1": [
+      {
+        "fun": {
+          "Fungible": 99000000000n,
+        },
+        "id": {
+          "Concrete": {
+            "interior": {
+              "X2": [
+                {
+                  "PalletInstance": 10,
+                },
+                {
+                  "GeneralIndex": "USDT",
+                },
+              ],
+            },
+            "parents": 0,
+          },
+        },
+      },
+      {
+        "fun": {
+          "Fungible": 5000000000n,
+        },
+        "id": {
+          "Concrete": {
+            "interior": "Here",
+            "parents": 1,
+          },
+        },
+      },
+    ],
+  },
+  1,
+  "Unlimited",
+]
+`;
+
+exports[`polkadotXcm > transferAssets > here > should be correct config 1`] = `
+ExtrinsicConfig {
+  "func": "transferAssets",
+  "getArgs": [Function],
+  "module": "polkadotXcm",
+}
+`;
+
+exports[`polkadotXcm > transferAssets > here > should get correct arguments 1`] = `
+[
+  {
+    "V1": {
+      "interior": {
+        "X1": {
+          "Parachain": 2032,
+        },
+      },
+      "parents": 1,
+    },
+  },
+  {
+    "V1": {
+      "interior": {
+        "X1": {
+          "AccountId32": {
+            "id": "0x18e6c7ad45fbab18778710642072fdd057470b76d4d568b44dea6accd5b0c423",
+            "network": null,
+          },
+        },
+      },
+      "parents": 0,
+    },
+  },
+  {
+    "V1": [
+      {
+        "fun": {
+          "Fungible": 99000000000n,
+        },
+        "id": {
+          "Concrete": {
+            "interior": "Here",
+            "parents": 1,
+          },
+        },
+      },
+    ],
+  },
+  0,
+  "Unlimited",
+]
+`;
+
 exports[`polkadotXcm > transferAssetsUsingTypeAndThen > globalConsensusEthereum > should be correct config 1`] = `
 ExtrinsicConfig {
   "func": "transferAssetsUsingTypeAndThen",

--- a/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.test.ts
+++ b/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.test.ts
@@ -119,6 +119,40 @@ describe('polkadotXcm', () => {
     });
   });
 
+  describe('transferAssets', () => {
+    describe('here', () => {
+      const extrinsic = polkadotXcm()
+        .transferAssets()
+        .here()
+        .build(buildParachainParamsMock);
+
+      it('should be correct config', () => {
+        expect(extrinsic).toMatchSnapshot();
+      });
+
+      it('should get correct arguments', () => {
+        expect(extrinsic.getArgs()).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('transferAssets', () => {
+    describe('X2AndFeeHere', () => {
+      const extrinsic = polkadotXcm()
+        .transferAssets()
+        .X2AndFeeHere()
+        .build(buildParachainParamsMock);
+
+      it('should be correct config', () => {
+        expect(extrinsic).toMatchSnapshot();
+      });
+
+      it('should get correct arguments', () => {
+        expect(extrinsic.getArgs()).toMatchSnapshot();
+      });
+    });
+  });
+
   describe('transferAssetsUsingTypeAndThen', () => {
     describe('globalConsensusEthereum', () => {
       const extrinsic = polkadotXcm()

--- a/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.ts
+++ b/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.ts
@@ -222,6 +222,53 @@ export function polkadotXcm() {
               },
             }),
         }),
+        X2AndFeeHere: (): ExtrinsicConfigBuilder => ({
+          build: (params) =>
+            new ExtrinsicConfig({
+              module: pallet,
+              func,
+              getArgs: (extrinsicFunction) => {
+                const version = getExtrinsicArgumentVersion(extrinsicFunction);
+
+                return getPolkadotXcmExtrinsicArgs({
+                  ...params,
+                  func: extrinsicFunction,
+                  asset: [
+                    {
+                      id: normalizeConcrete(version, {
+                        parents: 0,
+                        interior: {
+                          X2: [
+                            {
+                              PalletInstance:
+                                params.asset.getAssetPalletInstance(),
+                            },
+                            {
+                              GeneralIndex: params.asset.getAssetId(),
+                            },
+                          ],
+                        },
+                      }),
+                      fun: {
+                        Fungible: params.asset.amount,
+                      },
+                    },
+                    // Fee Asset
+                    {
+                      id: normalizeConcrete(version, {
+                        parents: 1,
+                        interior: 'Here',
+                      }),
+                      fun: {
+                        Fungible: params.fee.amount,
+                      },
+                    },
+                  ],
+                  feeIndex: 1,
+                });
+              },
+            }),
+        }),
       };
     },
     transferAssetsUsingTypeAndThen: () => {

--- a/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.util.ts
+++ b/packages/builder/src/extrinsic/pallets/polkadotXcm/polkadotXcm.util.ts
@@ -22,8 +22,7 @@ export function getPolkadotXcmExtrinsicArgs({
   func,
   parents = 1,
   feeIndex = 0,
-  // biome-ignore lint/suspicious/noExplicitAny: not sure how to fix this
-}: GetExtrinsicParams): any[] {
+}: GetExtrinsicParams) {
   const version = getExtrinsicArgumentVersion(func);
 
   return [

--- a/packages/config/src/xcm-configs/moonbeam.ts
+++ b/packages/config/src/xcm-configs/moonbeam.ts
@@ -857,7 +857,7 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: bifrostPolkadot,
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
-          amount: 0.00001,
+          amount: 0.7,
           asset: vastr,
         },
         min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
@@ -881,7 +881,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         chain: bifrostPolkadot,
         fee: {
-          amount: 0.0000001,
+          amount: 0.05,
           asset: vdot,
         },
         min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
@@ -905,7 +905,7 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: bifrostPolkadot,
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
-          amount: 0.00000001,
+          amount: 0.1,
           asset: vfil,
         },
         min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
@@ -929,7 +929,7 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: bifrostPolkadot,
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
-          amount: 0.00000001,
+          amount: 0.2,
           asset: vglmr,
         },
         min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
@@ -953,7 +953,7 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: bifrostPolkadot,
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
-          amount: 0.00000001,
+          amount: 0.05,
           asset: vmanta,
         },
         min: AssetMinBuilder().assetRegistry().currencyMetadatas(),

--- a/packages/config/src/xcm-configs/moonbeam.ts
+++ b/packages/config/src/xcm-configs/moonbeam.ts
@@ -639,13 +639,13 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: polkadotAssetHub,
         balance: BalanceBuilder().substrate().assets().account(),
         fee: {
-          amount: 0.05,
-          asset: usdt,
-          balance: BalanceBuilder().substrate().assets().account(), // TODO change when DOT pays for fees
+          amount: 0.01,
+          asset: dot,
+          balance: BalanceBuilder().substrate().system().account(),
         },
         min: AssetMinBuilder().assets().asset(),
       },
-      contract: ContractBuilder().Xtokens().transferMultiCurrencies(),
+      contract: ContractBuilder().Xtokens().transferMultiCurrencies(false),
     },
     {
       source: {
@@ -664,16 +664,13 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: polkadotAssetHub,
         balance: BalanceBuilder().substrate().assets().account(),
         fee: {
-          amount: 0.05,
-          asset: usdt,
-          balance: BalanceBuilder().substrate().assets().account(),
-          // TODO change when DOT pays for fees
-          // asset: dot,
-          // balance: BalanceBuilder().substrate().system().account(),
+          amount: 0.01,
+          asset: dot,
+          balance: BalanceBuilder().substrate().system().account(),
         },
         min: AssetMinBuilder().assets().asset(),
       },
-      contract: ContractBuilder().Xtokens().transferMultiCurrencies(),
+      contract: ContractBuilder().Xtokens().transferMultiCurrencies(false),
     },
     {
       source: {
@@ -692,9 +689,9 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: polkadotAssetHub,
         balance: BalanceBuilder().substrate().assets().account(),
         fee: {
-          amount: 0.05,
-          asset: usdt,
-          balance: BalanceBuilder().substrate().assets().account(), // TODO change when DOT pays for fees
+          amount: 0.01,
+          asset: dot,
+          balance: BalanceBuilder().substrate().system().account(),
         },
         min: AssetMinBuilder().assets().asset(),
       },
@@ -717,13 +714,13 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: polkadotAssetHub,
         balance: BalanceBuilder().substrate().assets().account(),
         fee: {
-          amount: 0.05,
-          asset: usdt,
-          balance: BalanceBuilder().substrate().assets().account(), // TODO change when DOT pays for fees
+          amount: 0.01,
+          asset: dot,
+          balance: BalanceBuilder().substrate().system().account(),
         },
         min: AssetMinBuilder().assets().asset(),
       },
-      contract: ContractBuilder().Xtokens().transferMultiCurrencies(),
+      contract: ContractBuilder().Xtokens().transferMultiCurrencies(false),
     },
     {
       source: {
@@ -1420,13 +1417,13 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: polkadotAssetHub,
         balance: BalanceBuilder().substrate().assets().account(),
         fee: {
-          amount: 0.05,
-          asset: usdt,
-          balance: BalanceBuilder().substrate().assets().account(), // TODO change when DOT pays for fees
+          amount: 0.01,
+          asset: dot,
+          balance: BalanceBuilder().substrate().system().account(),
         },
         min: AssetMinBuilder().assets().asset(),
       },
-      contract: ContractBuilder().Xtokens().transferMultiCurrencies(),
+      contract: ContractBuilder().Xtokens().transferMultiCurrencies(false),
     },
     {
       source: {

--- a/packages/config/src/xcm-configs/polkadotAssetHub.ts
+++ b/packages/config/src/xcm-configs/polkadotAssetHub.ts
@@ -132,15 +132,14 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
         fee: {
           amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
             isAssetReserveChain: false,
-            shouldTransferAssetPrecedeFeeAsset: true,
           }),
-          asset: usdt,
+          asset: dot,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssets()
+        .X2AndFeeHere(),
     },
     {
       source: {
@@ -163,15 +162,14 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
         fee: {
           amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
             isAssetReserveChain: false,
-            shouldTransferAssetPrecedeFeeAsset: true,
           }),
-          asset: usdt,
+          asset: dot,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssets()
+        .X2AndFeeHere(),
     },
     {
       source: {
@@ -195,13 +193,13 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
           amount: FeeBuilder()
             .xcmPaymentApi()
             .xcmPaymentFee({ isAssetReserveChain: false }),
-          asset: usdt,
+          asset: dot,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssets()
+        .X2AndFeeHere(),
     },
     {
       source: {
@@ -224,15 +222,14 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
         fee: {
           amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
             isAssetReserveChain: false,
-            shouldTransferAssetPrecedeFeeAsset: true,
           }),
-          asset: usdt,
+          asset: dot,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssets()
+        .X2AndFeeHere(),
     },
     {
       source: {
@@ -255,15 +252,14 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
         fee: {
           amount: FeeBuilder().xcmPaymentApi().xcmPaymentFee({
             isAssetReserveChain: false,
-            shouldTransferAssetPrecedeFeeAsset: true,
           }),
-          asset: usdt,
+          asset: dot,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssets()
+        .X2AndFeeHere(),
     },
     {
       source: {


### PR DESCRIPTION
- Change PINK, STINK, NCTR, DED and WIFD configs to use DOT as fee asset
- Add builder for new function to apply to these configs (polkadotXcm.transferAssets)
- Add tests for these functions