### PR TITLE
Change Redeem Wording

### DIFF
--- a/packages/builder/src/mrl/MrlBuilder.interfaces.ts
+++ b/packages/builder/src/mrl/MrlBuilder.interfaces.ts
@@ -15,9 +15,9 @@ export type MrlConfigBuilder = ConfigBuilder<
   MrlBuilderParams
 >;
 
-export type MrlRedeemConfigBuilder = ConfigBuilder<
+export type MrlExecuteConfigBuilder = ConfigBuilder<
   ContractConfig,
-  MrlRedeemBuilderParams
+  MrlExecuteBuilderParams
 >;
 
 export interface MrlBuilderParams extends BuilderParams<AnyChain> {
@@ -30,7 +30,7 @@ export interface MrlBuilderParams extends BuilderParams<AnyChain> {
   transact?: Transact;
 }
 
-export interface MrlRedeemBuilderParams {
+export interface MrlExecuteBuilderParams {
   bytes?: Uint8Array;
 }
 

--- a/packages/builder/src/mrl/providers/wormhole/contract/Gmp/Gmp.ts
+++ b/packages/builder/src/mrl/providers/wormhole/contract/Gmp/Gmp.ts
@@ -1,6 +1,6 @@
 import { u8aToHex } from '@polkadot/util';
 import { ContractConfig } from '../../../../../contract';
-import type { MrlRedeemConfigBuilder } from '../../../../MrlBuilder.interfaces';
+import type { MrlExecuteConfigBuilder } from '../../../../MrlBuilder.interfaces';
 import { GMP_ABI } from './GmpAbi';
 
 const module = 'GMP';
@@ -10,7 +10,7 @@ export const GMP_CONTRACT_ADDRESS =
 
 export function Gmp() {
   return {
-    wormholeTransferERC20: (): MrlRedeemConfigBuilder => ({
+    wormholeTransferERC20: (): MrlExecuteConfigBuilder => ({
       build: ({ bytes }) => {
         const hex = u8aToHex(bytes);
 

--- a/packages/mrl/src/getTransferData/getExecuteTransferData.ts
+++ b/packages/mrl/src/getTransferData/getExecuteTransferData.ts
@@ -1,18 +1,18 @@
 import { type ContractConfig, MrlBuilder } from '@moonbeam-network/xcm-builder';
 import { EvmService, type EvmSigner } from '@moonbeam-network/xcm-sdk';
 import type { EvmChain, EvmParachain } from '@moonbeam-network/xcm-types';
-import type { RedeemData } from '../mrl.interfaces';
+import type { ExecuteTransferData } from '../mrl.interfaces';
 import { WormholeService } from '../services/wormhole';
 
-export interface WormholeRedeemParams {
+export interface WormholeExecuteTransferParams {
   txId: string;
   chain: EvmChain | EvmParachain;
 }
 
-export async function getRedeemData({
+export async function getExecuteTransferData({
   txId,
   chain,
-}: WormholeRedeemParams): Promise<RedeemData> {
+}: WormholeExecuteTransferParams): Promise<ExecuteTransferData> {
   // TODO this is just for wormhole
   const wh = WormholeService.create(chain);
 
@@ -29,7 +29,7 @@ export async function getRedeemData({
   return {
     vaa,
     tokenTransfer,
-    async redeem(signer: EvmSigner) {
+    async executeTransfer(signer: EvmSigner) {
       const isComplete = await wh.isComplete(vaa, tokenTransfer);
 
       if (isComplete) {

--- a/packages/mrl/src/mrl.interfaces.ts
+++ b/packages/mrl/src/mrl.interfaces.ts
@@ -53,8 +53,8 @@ export interface ChainTransferData {
 }
 
 // TODO this is just for Wormhole
-export interface RedeemData {
+export interface ExecuteTransferData {
   vaa: TokenTransfer.VAA;
   tokenTransfer: TokenTransfer;
-  redeem(signer: EvmSigner): Promise<string>;
+  executeTransfer(signer: EvmSigner): Promise<string>;
 }

--- a/packages/mrl/src/mrl.ts
+++ b/packages/mrl/src/mrl.ts
@@ -5,9 +5,9 @@ import type {
   Ecosystem,
 } from '@moonbeam-network/xcm-types';
 import {
-  type WormholeRedeemParams,
-  getRedeemData,
-} from './getTransferData/getRedeemData';
+  type WormholeExecuteTransferParams,
+  getExecuteTransferData,
+} from './getTransferData/getExecuteTransferData';
 import { getTransferData } from './getTransferData/getTransferData';
 
 const DEFAULT_SERVICE = new ConfigService({ routes: mrlRoutesMap });
@@ -64,8 +64,8 @@ export function Mrl(options?: MrlOptions) {
         },
       };
     },
-    getRedeemData({ txId, chain }: WormholeRedeemParams) {
-      return getRedeemData({ txId, chain });
+    getExecuteTransferData({ txId, chain }: WormholeExecuteTransferParams) {
+      return getExecuteTransferData({ txId, chain });
     },
   };
 }


### PR DESCRIPTION
I decided to stop using the term 'redeem' and change it to 'execute transfer' as I feel that Redeem is not always correct. It might be correct when transferring to EVM chains, where executing the transfer gives you the tokens. But when transferring to parachains, when executing the transfer a contract call to the GMP precompile occurs, so no actual redeeming.

Wormhole themselves also changed the wording a while back. For example, the status that they called PENDING REDEEM is now called PENDING EXECUTION
