### PR TITLE
V3 Readmes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 PureStake
+Copyright 2025 Moonbeam Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Related Packages
+The Moonbeam XCM SDK enables developers to easily transfer assets between chains, either between parachains or between a parachain and the relay chain, within the Polkadot/Kusama ecosystem.
 
-- [XCM SDK](./packages/sdk/README.md) - Core SDK for executing XCM transfers between chains in the Polkadot/Kusama ecosystem
-- [MRL SDK](./packages/mrl/README.md) - Extension of the XCM SDK for transferring liquidity into and across the Polkadot ecosystem from other ecosystems
+Additionally, the Moonbeam MRL SDK enables developers to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. It uses the XCM SDK as base and adds the necessary functions to support MRL.
+
+# Main Packages
+
+- [XCM SDK](./packages/sdk/) - Core SDK for executing XCM transfers between chains in the Polkadot/Kusama ecosystem
+- [MRL SDK](./packages/mrl/) - Extension of the XCM SDK for transferring liquidity into and across the Polkadot ecosystem from other ecosystems

--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@ Additionally, the Moonbeam MRL SDK enables developers to easily transfer liquidi
 
 - [XCM SDK](./packages/sdk/) - Core SDK for executing XCM transfers between chains in the Polkadot/Kusama ecosystem
 - [MRL SDK](./packages/mrl/) - Extension of the XCM SDK for transferring liquidity into and across the Polkadot ecosystem from other ecosystems
+
+
+# Documentation
+
+## v3 (current)
+
+### Usage
+
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl)
+
+### References
+
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl)
+
+## v2 (previous)
+
+- [usage](https://moonbeam-foundation.github.io/xcm-sdk/v2/example-usage)
+- [references](https://moonbeam-foundation.github.io/xcm-sdk/v2/reference/interfaces)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-./packages/sdk/README.md
+# Related Packages
+
+- [XCM SDK](./packages/sdk/README.md) - Core SDK for executing XCM transfers between chains in the Polkadot/Kusama ecosystem
+- [MRL SDK](./packages/mrl/README.md) - Extension of the XCM SDK for transferring liquidity into and across the Polkadot ecosystem from other ecosystems

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 The Moonbeam XCM SDK enables developers to easily transfer assets between chains, either between parachains or between a parachain and the relay chain, within the Polkadot/Kusama ecosystem.
 
-Additionally, the Moonbeam MRL SDK enables developers to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. It uses the XCM SDK as base and adds the necessary functions to support MRL.
+Additionally, the Moonbeam MRL SDK allows users to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. It builds on the XCM SDK by adding necessary functions to support MRL.
 
 # Main Packages
 

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,14 +1,20 @@
-![Moonbeam](https://docs.moonbeam.network/images/builders/interoperability/xcm/sdk/xcm-sdk-banner.png)
+The Builder package contains the builders for the queries, extrinsics, functions, and contract calls used in the Moonbeam XCM SDK and MRL SDK.
 
-The Moonbeam XCM SDK enables developers to easily deposit and withdraw assets to Moonbeam/Moonriver from the relay chain and other parachains in the Polkadot/Kusama ecosystem. With the SDK, you don't need to worry about determining the multilocation of the origin or destination assets or which extrinsics are used on which networks to send XCM transfers. To deposit or withdraw assets, you simply define the asset and origin chain you want to deposit from or withdraw back to, along with the sending account's signer, and the amount to send.
+# Documentation for the Moonbeam XCM SDK
 
-# Documentation
+## v3 (current)
 
-## v1 (current)
+### Usage
 
-- TODO: (coming soon)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl)
 
-## v0 (previous)
+### References
 
-- [usage](https://docs.moonbeam.network/builders/xcm/xcm-sdk/xcm-sdk/)
-- [references](https://docs.moonbeam.network/builders/xcm/xcm-sdk/reference/)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl)
+
+## v2 (previous)
+
+- [usage](https://moonbeam-foundation.github.io/xcm-sdk/v2/example-usage)
+- [references](https://moonbeam-foundation.github.io/xcm-sdk/v2/reference/interfaces)

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,14 +1,20 @@
-![Moonbeam](https://docs.moonbeam.network/images/builders/interoperability/xcm/sdk/xcm-sdk-banner.png)
+The Config package contains the chains and assets configuration for the Moonbeam XCM SDK and MRL SDK.
 
-The Moonbeam XCM SDK enables developers to easily deposit and withdraw assets to Moonbeam/Moonriver from the relay chain and other parachains in the Polkadot/Kusama ecosystem. With the SDK, you don't need to worry about determining the multilocation of the origin or destination assets or which extrinsics are used on which networks to send XCM transfers. To deposit or withdraw assets, you simply define the asset and origin chain you want to deposit from or withdraw back to, along with the sending account's signer, and the amount to send.
+# Documentation for the Moonbeam XCM SDK
 
-# Documentation
+## v3 (current)
 
-## v1 (current)
+### Usage
 
-- TODO: (coming soon)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl)
 
-## v0 (previous)
+### References
 
-- [usage](https://docs.moonbeam.network/builders/xcm/xcm-sdk/xcm-sdk/)
-- [references](https://docs.moonbeam.network/builders/xcm/xcm-sdk/reference/)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl)
+
+## v2 (previous)
+
+- [usage](https://moonbeam-foundation.github.io/xcm-sdk/v2/example-usage)
+- [references](https://moonbeam-foundation.github.io/xcm-sdk/v2/reference/interfaces)

--- a/packages/mrl/README.md
+++ b/packages/mrl/README.md
@@ -1,6 +1,6 @@
-The Moonbeam MRL SDK enables developers to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. With the SDK, you don't need to worry about setting up the different contract calls and extrisics involved in the process of movin assets between the chains and ecosystems. It is an extension  of the XCM SDK as it uses the same config and utils.
+The Moonbeam MRL SDK enables developers to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. With the SDK, you don't need to worry about setting up the different contract calls and extrinsics involved in the process of moving assets between the chains and ecosystems. It is an extension of the XCM SDK as it uses the same config and utils.
 
-The MRL SDK offers helper functions, that provide a very simple interface to execute transfers from parachains or contract calls from EVM chains. In addition, the MRL config package allows any external project to add their information in a standard way, so they can be immediately supported by the MRL SDK.
+The MRL SDK offers helper functions that provide a very simple interface to execute transfers from parachains or contract calls from EVM chains. In addition, the MRL config package allows any external project to add their information in a standard way, allowing immediate support by the MRL SDK.
 
 # Documentation
 

--- a/packages/mrl/README.md
+++ b/packages/mrl/README.md
@@ -1,1 +1,135 @@
-// TODO:
+The Moonbeam MRL SDK enables developers to easily transfer liquidity into and across the Polkadot ecosystem from other ecosystems like Ethereum. With the SDK, you don't need to worry about setting up the different contract calls and extrisics involved in the process of movin assets between the chains and ecosystems. It is an extension  of the XCM SDK as it uses the same config and utils.
+
+The MRL SDK offers helper functions, that provide a very simple interface to execute transfers from parachains or contract calls from EVM chains. In addition, the MRL config package allows any external project to add their information in a standard way, so they can be immediately supported by the MRL SDK.
+
+# Documentation
+
+You can find the documentation at [https://moonbeam-foundation.github.io/xcm-sdk/latest/](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl/).
+
+# Installation
+
+```bash
+npm i @moonbeam-network/mrl
+```
+
+:warning: You need to have peer dependencies of SDK installed as well.
+
+```bash
+npm install @polkadot/api @polkadot/util-crypto
+```
+
+# Usage
+
+The following sections contain basic examples of how to work with the MRL SDK to build transfer data to transfer an asset from one chain to another and how to submit the transfer. For a detailed overview on how to use it, please refer to the [XCM SDK docs](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl).
+
+## Build MRL Transfer Data
+
+```js
+import { Mrl } from '@moonbeam-network/mrl';
+
+const fromEvm = async () => {
+  const transferData = await Mrl()
+    .setSource(INSERT_SOURCE_CHAIN)
+    .setDestination(INSERT_DESTINATION_CHAIN)
+    .setAsset(INSERT_ASSET)
+    .setIsAutomatic(INSERT_IF_IS_AUTOMATIC)
+    .setAddresses({
+      sourceAddress: INSERT_SOURCE_ADDRESS,
+      destinationAddress: INSERT_DESTINATION_ADDRESS,
+    });
+};
+
+fromEvm();
+```	
+
+## Transfer
+
+```js
+...
+
+const hash = await transferData.transfer(INSERT_TRANSFER_AMOUNT, INSERT_IF_IS_AUTOMATIC, { INSERT_SIGNERS });
+
+```
+
+# Examples
+
+- [mrl](https://github.com/moonbeam-foundation/xcm-sdk/blob/main/examples/mrl-simple)
+
+```bash
+git clone git@github.com:moonbeam-foundation/xcm-sdk.git
+cd xcm-sdk
+pnpm install
+cd examples/mrl-simple
+
+# edit index.ts by adding your accounts
+
+pnpm run start
+```
+
+# Contributing
+
+First fork the repository and clone it.
+
+```bash
+git clone git@github.com:YOUR_GITHUB_USERNAME/xcm-sdk.git
+pnpm install
+```
+
+Optionally, you can install the `pre-commit` hook to run the linter and tests before committing:
+
+```bash
+pnpm lefthook install
+```
+
+# Tests
+
+## Unit tests
+
+```bash
+pnpm run test
+```
+
+## Acceptance tests
+
+```bash
+pnpm run test:acc
+```
+
+# Release
+
+To create a dev version go to GitHub actions and run `publish dev versions` workflow.
+
+To create a release version run:
+
+```bash
+pnpm run changeset
+```
+
+# Testing the change in the SDK locally
+
+Build the project:
+
+```bash
+pnpm run build
+```
+
+Link the SDK:
+
+```bash
+pnpm run clean && pnpm run build && pnpm run link
+```
+
+In your project where you would like to test the changes:
+
+```bash
+pnpm link @moonbeam-network/xcm-types @moonbeam-network/xcm-utils @moonbeam-network/xcm-builder @moonbeam-network/xcm-config @moonbeam-network/xcm-sdk @moonbeam-network/mrl
+```
+
+If you need you can link other packages too.
+
+After testing is done, unlink the SDK:
+
+```bash
+pnpm unlink @moonbeam-network/xcm-types @moonbeam-network/xcm-utils @moonbeam-network/xcm-builder @moonbeam-network/xcm-config @moonbeam-network/xcm-sdk @moonbeam-network/mrl
+```
+

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 The Moonbeam XCM SDK enables developers to easily transfer assets between chains, either between parachains or between a parachain and the relay chain, within the Polkadot/Kusama ecosystem. With the SDK, you don't need to worry about determining the multilocation of the origin or destination assets or which extrinsics are used on which networks to send XCM transfers.
 
-The XCM SDK offers helper functions, that provide a very simple interface to execute XCM transfers between chains in the Polkadot/Kusama ecosystem. In addition, the XCM config package allows any parachain project to add their information in a standard way, so they can be immediately supported by the XCM SDK.
+The XCM SDK offers helper functions that provide a very simple interface to execute XCM transfers between chains in the Polkadot/Kusama ecosystem. In addition, the XCM config package allows any parachain project to add their information in a standard way, so they can be immediately supported by the XCM SDK.
 
 # Documentation
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -15,40 +15,30 @@ npm i @moonbeam-network/xcm-sdk
 :warning: You need to have peer dependencies of SDK installed as well.
 
 ```bash
-npm i @polkadot/api @polkadot/api-augment @polkadot/types @polkadot/util @polkadot/util-crypto @polkadot/apps-config ethers
+npm i @polkadot/api @polkadot/util-crypto
 ```
 
 # Usage
 
-The following sections contain basic examples of how to work with the XCM SDK to build transfer data to transfer an asset from one chain to another and how to submit the transfer. For a detailed overview on how to use each method, including a reference to the parameters and returned data of each method exposed by the SDK, please refer to the [XCM SDK docs](https://docs.moonbeam.network/builders/interoperability/xcm/xcm-sdk/v1/).
+The following sections contain basic examples of how to work with the XCM SDK to build transfer data to transfer an asset from one chain to another and how to submit the transfer. For a detailed overview on how to use it, please refer to the [XCM SDK docs](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm).
 
 ## Build XCM Transfer Data
 
 ```js
 import { Sdk } from '@moonbeam-network/xcm-sdk';
 
-const { assets, getTransferData } = Sdk();
+const transferData = async () => {
+  const transferData = await Sdk()
+  .setAsset(INSERT_ASSET)
+  .setSource(INSERT_SOURCE_CHAIN)
+  .setDestination(INSERT_DESTINATION_CHAIN)
+  .setAddresses({
+    sourceAddress: INSERT_SOURCE_ADDRESS,
+      destinationAddress: INSERT_DESTINATION_ADDRESS,
+    });
+  };
 
-// You can build the XCM transfer data via the assets function
-const dataViaAssetsMethod = await assets()
-  .asset('INSERT_ASSET')
-  .source('INSERT_SOURCE_CHAIN')
-  .destination('INSERT_DESTINATION_CHAIN')
-  .accounts('INSERT_SOURCE_ADDRESS', 'INSERT_DESTINATION_ADDRESS', {
-    evmSigner?: 'INSERT_EVM_SIGNER',
-    polkadotSigner?: 'INSERT_POLKADOT_SIGNER',
-  });
-
-// Or via the getTransferData function
-const dataViaGetTransferDataMethod = await getTransferData({
-  destinationAddress: 'INSERT_DESTINATION_ADDRESS',
-  destinationKeyOrChain: 'INSERT_DESTINATION_CHAIN',
-  evmSigner?: 'INSERT_EVM_SIGNER',
-  keyOrAsset: 'INSERT_ASSET',
-  polkadotSigner?: 'INSERT_POLKADOT_SIGNER',
-  sourceAddress: 'INSERT_SOURCE_ADDRESS',
-  sourceKeyOrChain: 'INSERT_SOURCE_CHAIN',
-});
+fromPolkadot();
 ```
 
 ## Transfer
@@ -56,7 +46,7 @@ const dataViaGetTransferDataMethod = await getTransferData({
 ```js
 ...
 
-const hash = await dataViaGetTransferDataMethod.transfer('INSERT_TRANSFER_AMOUNT');
+const hash = await transferData.transfer(INSERT_TRANSFER_AMOUNT, { INSERT_SIGNERS });
 ```
 
 # Examples
@@ -76,10 +66,11 @@ pnpm run start
 
 # Contributing
 
+First fork the repository and clone it.
+
 ```bash
-git clone git@github.com:moonbeam-foundation/xcm-sdk.git
+git clone git@github.com:YOUR_GITHUB_USERNAME/xcm-sdk.git
 pnpm install
-pnpm run dev
 ```
 
 Optionally, you can install the `pre-commit` hook to run the linter and tests before committing:
@@ -99,9 +90,6 @@ pnpm run test
 ## Acceptance tests
 
 ```bash
-cp .env.example .env
-# add private key and suri to .env file
-
 pnpm run test:acc
 ```
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,4 +1,4 @@
-The Types package contains the types definitions for the Moonbeam XCM SDK and MRL SDK.
+The Types package contains the type definitions for the Moonbeam XCM SDK and MRL SDK.
 
 # Documentation for the Moonbeam XCM SDK
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,14 +1,20 @@
-![Moonbeam](https://docs.moonbeam.network/images/builders/interoperability/xcm/sdk/xcm-sdk-banner.png)
+The Types package contains the types definitions for the Moonbeam XCM SDK and MRL SDK.
 
-The Moonbeam XCM SDK enables developers to easily deposit and withdraw assets to Moonbeam/Moonriver from the relay chain and other parachains in the Polkadot/Kusama ecosystem. With the SDK, you don't need to worry about determining the multilocation of the origin or destination assets or which extrinsics are used on which networks to send XCM transfers. To deposit or withdraw assets, you simply define the asset and origin chain you want to deposit from or withdraw back to, along with the sending account's signer, and the amount to send.
+# Documentation for the Moonbeam XCM SDK
 
-# Documentation
+## v3 (current)
 
-## v1 (current)
+### Usage
 
-- TODO: (coming soon)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl)
 
-## v0 (previous)
+### References
 
-- [usage](https://docs.moonbeam.network/builders/xcm/xcm-sdk/xcm-sdk/)
-- [references](https://docs.moonbeam.network/builders/xcm/xcm-sdk/reference/)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl)
+
+## v2 (previous)
+
+- [usage](https://moonbeam-foundation.github.io/xcm-sdk/v2/example-usage)
+- [references](https://moonbeam-foundation.github.io/xcm-sdk/v2/reference/interfaces)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,9 +1,20 @@
-![Moonbeam](https://docs.moonbeam.network/images/builders/interoperability/xcm/sdk/xcm-sdk-banner.png)
+The Utils package contains the utility functions for the Moonbeam XCM SDK and MRL SDK.
 
-The Moonbeam XCM SDK enables developers to easily deposit and withdraw assets to Moonbeam/Moonriver from the relay chain and other parachains in the Polkadot/Kusama ecosystem. With the SDK, you don't need to worry about determining the multilocation of the origin or destination assets or which extrinsics are used on which networks to send XCM transfers. To deposit or withdraw assets, you simply define the asset and origin chain you want to deposit from or withdraw back to, along with the sending account's signer, and the amount to send.
+# Documentation for the Moonbeam XCM SDK
 
-# Documentation
+## v3 (current)
 
-## v1 (current)
+### Usage
 
-- TODO: (coming soon)
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/example-usage/mrl)
+
+### References
+
+- [XCM SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/xcm)
+- [MRL SDK](https://moonbeam-foundation.github.io/xcm-sdk/latest/reference/mrl)
+
+## v2 (previous)
+
+- [usage](https://moonbeam-foundation.github.io/xcm-sdk/v2/example-usage)
+- [references](https://moonbeam-foundation.github.io/xcm-sdk/v2/reference/interfaces)


### PR DESCRIPTION
- Replace the symlink in the base Readme for an actual file redirecting to the two main packages and their readme files
- Adapt / update the rest of the Readme files
- Update License