### PR TITLE
Unify node versions and apply lint in changeset PR

### DIFF
--- a/.changeset/dull-dragons-happen.md
+++ b/.changeset/dull-dragons-happen.md
@@ -1,0 +1,5 @@
+---
+"@moonbeam-network/xcm-utils": patch
+---
+
+PAtch bump to test changeset fix in release flow

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: 🔐 Authenticate with NPM

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ".nvmrc"
           cache: 'pnpm'
 
       - name: 🔐 Authenticate with NPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: ⬇️  Install dependencies

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - run: pnpm install --ignore-scripts

--- a/.github/workflows/xcm-wss-endpoints-monitor.yml
+++ b/.github/workflows/xcm-wss-endpoints-monitor.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: ".nvmrc"
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: ⬇️ install

--- a/.github/workflows/xcm-wss-endpoints-monitor.yml
+++ b/.github/workflows/xcm-wss-endpoints-monitor.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⚙ Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ".nvmrc"
           cache: 'pnpm'
 
       - name: ⬇️ install

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf packages/**/build packages/**/.turbo .turbo/",
     "changeset": "changeset",
     "changeset:status": "changeset status",
-    "changeset:version": "changeset version && pnpm install --lockfile-only",
+    "changeset:version": "changeset version && pnpm install --lockfile-only && pnpm lint:fix",
     "changeset:publish": "pnpm run build && changeset publish"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

- Unify node version in all the github actions
- Run lint script after `changeset version` to prevent lint errors in the changeset PRs

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
