### PR TITLE
Overwrite ANKR endpoints in Wormhole

### DIFF
--- a/.changeset/shiny-roses-divide.md
+++ b/.changeset/shiny-roses-divide.md
@@ -1,0 +1,7 @@
+---
+"@moonbeam-network/xcm-builder": patch
+"@moonbeam-network/xcm-types": patch
+"@moonbeam-network/mrl": patch
+---
+
+Override Wormhole endpoints

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "@polkadot/types": "15.8.1",
     "@polkadot/util": "13.4.3",
     "@polkadot/util-crypto": "13.4.3",
-    "@wormhole-foundation/sdk-connect": "^1.13.2",
-    "@wormhole-foundation/sdk-evm": "^1.13.2",
-    "@wormhole-foundation/sdk-evm-tokenbridge": "^1.13.2"
+    "@wormhole-foundation/sdk-connect": "^1.13.3",
+    "@wormhole-foundation/sdk-evm": "^1.13.3",
+    "@wormhole-foundation/sdk-evm-tokenbridge": "^1.13.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -43,8 +43,8 @@
     "@polkadot/types": "15.8.1",
     "@polkadot/util": "13.4.3",
     "@polkadot/util-crypto": "13.4.3",
-    "@wormhole-foundation/sdk-connect": "^1.13.2",
-    "@wormhole-foundation/sdk-evm": "^1.13.2",
+    "@wormhole-foundation/sdk-connect": "^1.13.3",
+    "@wormhole-foundation/sdk-evm": "^1.13.3",
     "viem": "^2.23.2"
   }
 }

--- a/packages/builder/src/mrl/providers/wormhole/wormhole/wormholeFactory.ts
+++ b/packages/builder/src/mrl/providers/wormhole/wormhole/wormholeFactory.ts
@@ -3,5 +3,18 @@ import { Wormhole } from '@wormhole-foundation/sdk-connect';
 import { EvmPlatform } from '@wormhole-foundation/sdk-evm';
 
 export function wormholeFactory(chain: AnyChain) {
-  return new Wormhole(chain.isTestChain ? 'Testnet' : 'Mainnet', [EvmPlatform]);
+  return new Wormhole(
+    chain.isTestChain ? 'Testnet' : 'Mainnet',
+    [EvmPlatform],
+    {
+      chains: {
+        Ethereum: {
+          rpc: 'https://eth.llamarpc.com',
+        },
+        Moonbeam: {
+          rpc: 'https://rpc.api.moonbeam.network',
+        },
+      },
+    },
+  );
 }

--- a/packages/mrl/package.json
+++ b/packages/mrl/package.json
@@ -46,8 +46,8 @@
     "@polkadot/types": "15.8.1",
     "@polkadot/util": "13.4.3",
     "@polkadot/util-crypto": "13.4.3",
-    "@wormhole-foundation/sdk-connect": "^1.13.2",
-    "@wormhole-foundation/sdk-evm": "^1.13.2",
+    "@wormhole-foundation/sdk-connect": "^1.13.3",
+    "@wormhole-foundation/sdk-evm": "^1.13.3",
     "viem": "^2.23.2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/big.js": "^6.2.2",
-    "@wormhole-foundation/sdk-connect": "^1.13.2"
+    "@wormhole-foundation/sdk-connect": "^1.13.3"
   },
   "peerDependencies": {
     "viem": "^2.23.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,11 +160,11 @@ importers:
         specifier: 13.4.3
         version: 13.4.3(@polkadot/util@13.4.3)
       '@wormhole-foundation/sdk-connect':
-        specifier: ^1.13.2
-        version: 1.13.2
+        specifier: ^1.13.3
+        version: 1.13.3
       '@wormhole-foundation/sdk-evm':
-        specifier: ^1.13.2
-        version: 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        specifier: ^1.13.3
+        version: 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       big.js:
         specifier: ^6.2.1
         version: 6.2.2
@@ -226,11 +226,11 @@ importers:
         specifier: 13.4.3
         version: 13.4.3(@polkadot/util@13.4.3)
       '@wormhole-foundation/sdk-connect':
-        specifier: ^1.13.2
-        version: 1.13.2
+        specifier: ^1.13.3
+        version: 1.13.3
       '@wormhole-foundation/sdk-evm':
-        specifier: ^1.13.2
-        version: 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        specifier: ^1.13.3
+        version: 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       big.js:
         specifier: ^6.2.1
         version: 6.2.2
@@ -291,8 +291,8 @@ importers:
         specifier: ^6.2.2
         version: 6.2.2
       '@wormhole-foundation/sdk-connect':
-        specifier: ^1.13.2
-        version: 1.13.2
+        specifier: ^1.13.3
+        version: 1.13.3
 
   packages/utils:
     dependencies:
@@ -2016,22 +2016,12 @@ packages:
   '@vitest/utils@3.0.8':
     resolution: {integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==}
 
-  '@wormhole-foundation/sdk-base@1.13.2':
-    resolution: {integrity: sha512-3vffr+gTR1afQjsxGZXzV8WHO6/Wd4a7ppD5d0rGFA3JNMw5iWe3/7y7YOFAA+QXowp+55cgk4WNnxzVIHaVqg==}
-
   '@wormhole-foundation/sdk-base@1.13.3':
     resolution: {integrity: sha512-W3wznHmgZMCOZMKIlh0b5BFohjPkuOLs2PQVK9AKHPsMMG3Xs005SShF2xWCeStoctMmQuAEvr6nHv/J7RbpfQ==}
-
-  '@wormhole-foundation/sdk-connect@1.13.2':
-    resolution: {integrity: sha512-0YKdhI/L3IKRxEGfguYAnzH6kbdlWQPtEO+VaomVuKN7XM+aYBrAUCMauA6/JAYY+MMXwQsnHUfrfdLXhcsT6g==}
-    engines: {node: '>=16'}
 
   '@wormhole-foundation/sdk-connect@1.13.3':
     resolution: {integrity: sha512-o3hzi5IUUtz8Xo9cGpVGqNIJJDIwv7BRdrGHYDgPgRGgdxBfhN+SJGEXaOcMhgDqgJefmlWlbVtvIL8HWx52Ig==}
     engines: {node: '>=16'}
-
-  '@wormhole-foundation/sdk-definitions@1.13.2':
-    resolution: {integrity: sha512-oE2ppRsjrdCpvFkMiqNnQmOXMa19H0BF4RueeYaMrtE057J6YukmZbUeLcQrF52ZsJ7fAtgorOfPJYNOCxdadQ==}
 
   '@wormhole-foundation/sdk-definitions@1.13.3':
     resolution: {integrity: sha512-RokDwspbtJjTsVwZ/LX1TKza49V1M8+sluL2fMG8tDxKR13EVyOXVFDQ9gCKTdJkO4ou69BXQRH0aUvXxHk6lg==}
@@ -2042,10 +2032,6 @@ packages:
 
   '@wormhole-foundation/sdk-evm-tokenbridge@1.13.3':
     resolution: {integrity: sha512-URdMgqmP4PLiWDwFOfGH8+wqycr9FtiAvec9mPivp/pQzuD/O5wmDecymGXME6ELuWg76DgZFZWYft9NGnVJBQ==}
-    engines: {node: '>=16'}
-
-  '@wormhole-foundation/sdk-evm@1.13.2':
-    resolution: {integrity: sha512-WCyk44cbBtG+9VSOSj6UToGhaH4Os1efsBbGStfQzUdwGQ0z6GSo8G4aHet5CFVSZHj7PigvU3iwPirKkidfBA==}
     engines: {node: '>=16'}
 
   '@wormhole-foundation/sdk-evm@1.13.3':
@@ -6311,23 +6297,10 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@wormhole-foundation/sdk-base@1.13.2':
-    dependencies:
-      '@scure/base': 1.2.4
-      binary-layout: 1.2.0
-
   '@wormhole-foundation/sdk-base@1.13.3':
     dependencies:
       '@scure/base': 1.2.4
       binary-layout: 1.2.0
-
-  '@wormhole-foundation/sdk-connect@1.13.2':
-    dependencies:
-      '@wormhole-foundation/sdk-base': 1.13.2
-      '@wormhole-foundation/sdk-definitions': 1.13.2
-      axios: 1.8.3
-    transitivePeerDependencies:
-      - debug
 
   '@wormhole-foundation/sdk-connect@1.13.3':
     dependencies:
@@ -6336,12 +6309,6 @@ snapshots:
       axios: 1.8.3
     transitivePeerDependencies:
       - debug
-
-  '@wormhole-foundation/sdk-definitions@1.13.2':
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@wormhole-foundation/sdk-base': 1.13.2
 
   '@wormhole-foundation/sdk-definitions@1.13.3':
     dependencies:
@@ -6364,15 +6331,6 @@ snapshots:
       '@wormhole-foundation/sdk-connect': 1.13.3
       '@wormhole-foundation/sdk-evm': 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@wormhole-foundation/sdk-evm-core': 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
-  '@wormhole-foundation/sdk-evm@1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@wormhole-foundation/sdk-connect': 1.13.2
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,14 +37,14 @@ importers:
         specifier: 13.4.3
         version: 13.4.3(@polkadot/util@13.4.3)
       '@wormhole-foundation/sdk-connect':
-        specifier: ^1.13.2
-        version: 1.13.2
+        specifier: ^1.13.3
+        version: 1.13.3
       '@wormhole-foundation/sdk-evm':
-        specifier: ^1.13.2
-        version: 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        specifier: ^1.13.3
+        version: 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@wormhole-foundation/sdk-evm-tokenbridge':
-        specifier: ^1.13.2
-        version: 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        specifier: ^1.13.3
+        version: 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -2019,23 +2019,37 @@ packages:
   '@wormhole-foundation/sdk-base@1.13.2':
     resolution: {integrity: sha512-3vffr+gTR1afQjsxGZXzV8WHO6/Wd4a7ppD5d0rGFA3JNMw5iWe3/7y7YOFAA+QXowp+55cgk4WNnxzVIHaVqg==}
 
+  '@wormhole-foundation/sdk-base@1.13.3':
+    resolution: {integrity: sha512-W3wznHmgZMCOZMKIlh0b5BFohjPkuOLs2PQVK9AKHPsMMG3Xs005SShF2xWCeStoctMmQuAEvr6nHv/J7RbpfQ==}
+
   '@wormhole-foundation/sdk-connect@1.13.2':
     resolution: {integrity: sha512-0YKdhI/L3IKRxEGfguYAnzH6kbdlWQPtEO+VaomVuKN7XM+aYBrAUCMauA6/JAYY+MMXwQsnHUfrfdLXhcsT6g==}
+    engines: {node: '>=16'}
+
+  '@wormhole-foundation/sdk-connect@1.13.3':
+    resolution: {integrity: sha512-o3hzi5IUUtz8Xo9cGpVGqNIJJDIwv7BRdrGHYDgPgRGgdxBfhN+SJGEXaOcMhgDqgJefmlWlbVtvIL8HWx52Ig==}
     engines: {node: '>=16'}
 
   '@wormhole-foundation/sdk-definitions@1.13.2':
     resolution: {integrity: sha512-oE2ppRsjrdCpvFkMiqNnQmOXMa19H0BF4RueeYaMrtE057J6YukmZbUeLcQrF52ZsJ7fAtgorOfPJYNOCxdadQ==}
 
-  '@wormhole-foundation/sdk-evm-core@1.13.2':
-    resolution: {integrity: sha512-V8kg+8DJa8lIIAtOkDbjx1QkhbUDtxM1L7NoRnfZ7IHqcwc54UuOlULpe+GxywYiXWfq99NfOHfbzq65jRwyjA==}
+  '@wormhole-foundation/sdk-definitions@1.13.3':
+    resolution: {integrity: sha512-RokDwspbtJjTsVwZ/LX1TKza49V1M8+sluL2fMG8tDxKR13EVyOXVFDQ9gCKTdJkO4ou69BXQRH0aUvXxHk6lg==}
+
+  '@wormhole-foundation/sdk-evm-core@1.13.3':
+    resolution: {integrity: sha512-d1Fon8Jh3iRc4ohhm5pGGVFyGVdIhRqyWeDN+2401/ShKxx1QCGGQcJ3DCH2OHlFCU5lEs59qxjf1whDldf7iA==}
     engines: {node: '>=16'}
 
-  '@wormhole-foundation/sdk-evm-tokenbridge@1.13.2':
-    resolution: {integrity: sha512-yFMczTmcRXRbuWuUjqaUesFrmpkf81k5E1XLs/cdbuG4nIBEumVY9upi46zlGm5KUK5wre6iZdlVfvxWOivg3A==}
+  '@wormhole-foundation/sdk-evm-tokenbridge@1.13.3':
+    resolution: {integrity: sha512-URdMgqmP4PLiWDwFOfGH8+wqycr9FtiAvec9mPivp/pQzuD/O5wmDecymGXME6ELuWg76DgZFZWYft9NGnVJBQ==}
     engines: {node: '>=16'}
 
   '@wormhole-foundation/sdk-evm@1.13.2':
     resolution: {integrity: sha512-WCyk44cbBtG+9VSOSj6UToGhaH4Os1efsBbGStfQzUdwGQ0z6GSo8G4aHet5CFVSZHj7PigvU3iwPirKkidfBA==}
+    engines: {node: '>=16'}
+
+  '@wormhole-foundation/sdk-evm@1.13.3':
+    resolution: {integrity: sha512-JyarHHxQyL2XRQUwp7ITtnayTQCiqQCjATL43CSRQ5x2YCeq7uKLThsTKB8xze3eCPC/5AQWAvuCrtUDItH3ZA==}
     engines: {node: '>=16'}
 
   '@zeitgeistpm/type-defs@1.0.0':
@@ -6302,10 +6316,23 @@ snapshots:
       '@scure/base': 1.2.4
       binary-layout: 1.2.0
 
+  '@wormhole-foundation/sdk-base@1.13.3':
+    dependencies:
+      '@scure/base': 1.2.4
+      binary-layout: 1.2.0
+
   '@wormhole-foundation/sdk-connect@1.13.2':
     dependencies:
       '@wormhole-foundation/sdk-base': 1.13.2
       '@wormhole-foundation/sdk-definitions': 1.13.2
+      axios: 1.8.3
+    transitivePeerDependencies:
+      - debug
+
+  '@wormhole-foundation/sdk-connect@1.13.3':
+    dependencies:
+      '@wormhole-foundation/sdk-base': 1.13.3
+      '@wormhole-foundation/sdk-definitions': 1.13.3
       axios: 1.8.3
     transitivePeerDependencies:
       - debug
@@ -6316,21 +6343,27 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@wormhole-foundation/sdk-base': 1.13.2
 
-  '@wormhole-foundation/sdk-evm-core@1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+  '@wormhole-foundation/sdk-definitions@1.13.3':
     dependencies:
-      '@wormhole-foundation/sdk-connect': 1.13.2
-      '@wormhole-foundation/sdk-evm': 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@wormhole-foundation/sdk-base': 1.13.3
+
+  '@wormhole-foundation/sdk-evm-core@1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@wormhole-foundation/sdk-connect': 1.13.3
+      '@wormhole-foundation/sdk-evm': 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - utf-8-validate
 
-  '@wormhole-foundation/sdk-evm-tokenbridge@1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+  '@wormhole-foundation/sdk-evm-tokenbridge@1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
-      '@wormhole-foundation/sdk-connect': 1.13.2
-      '@wormhole-foundation/sdk-evm': 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@wormhole-foundation/sdk-evm-core': 1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@wormhole-foundation/sdk-connect': 1.13.3
+      '@wormhole-foundation/sdk-evm': 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@wormhole-foundation/sdk-evm-core': 1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -6340,6 +6373,15 @@ snapshots:
   '@wormhole-foundation/sdk-evm@1.13.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@wormhole-foundation/sdk-connect': 1.13.2
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@wormhole-foundation/sdk-evm@1.13.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@wormhole-foundation/sdk-connect': 1.13.3
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
### Description

- Ankr endpoints are down, and Wormhole uses them as default. Until it is fixed there we should overwrite them

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
