### PR TITLE
Fix Bifrost Fees

### DIFF
--- a/.changeset/plenty-cats-worry.md
+++ b/.changeset/plenty-cats-worry.md
@@ -2,4 +2,4 @@
 "@moonbeam-network/xcm-config": patch
 ---
 
-Fix Bifrost fees
+Fix Bifrost fees and remove BNCS

--- a/.changeset/plenty-cats-worry.md
+++ b/.changeset/plenty-cats-worry.md
@@ -1,0 +1,5 @@
+---
+"@moonbeam-network/xcm-config": patch
+---
+
+Fix Bifrost fees

--- a/packages/config/src/assets.ts
+++ b/packages/config/src/assets.ts
@@ -50,11 +50,6 @@ export const bnc = new Asset({
   originSymbol: 'BNC',
 });
 
-export const bncs = new Asset({
-  key: 'bncs',
-  originSymbol: 'BNCS',
-});
-
 export const cfg = new Asset({
   key: 'cfg',
   originSymbol: 'CFG',
@@ -426,7 +421,6 @@ export const assetsList: Asset[] = [
   auq,
   axlusdc,
   bnc,
-  bncs,
   cfg,
   crab,
   csm,

--- a/packages/config/src/chains.ts
+++ b/packages/config/src/chains.ts
@@ -18,7 +18,6 @@ import {
   auq,
   axlusdc,
   bnc,
-  bncs,
   cfg,
   crab,
   csm,
@@ -288,16 +287,6 @@ export const bifrostPolkadot = new Parachain({
         generalKey: {
           length: 2,
           data: '0x0001000000000000000000000000000000000000000000000000000000000000',
-        },
-      },
-    }),
-    ChainAsset.fromAsset(bncs, {
-      decimals: 12,
-      ids: {
-        id: { Token2: 9 },
-        generalKey: {
-          length: 2,
-          data: '0x0809000000000000000000000000000000000000000000000000000000000000',
         },
       },
     }),
@@ -1153,13 +1142,6 @@ export const moonbeam = new EvmParachain({
       decimals: 12,
       ids: {
         id: '165823357460190568952172802245839421906',
-      },
-    }),
-    ChainAsset.fromAsset(bncs, {
-      address: '0xfFfffffF6aF229AE7f0F4e0188157e189a487D59',
-      decimals: 12,
-      ids: {
-        id: '142155548796783636521833385094843759961',
       },
     }),
     ChainAsset.fromAsset(cfg, {

--- a/packages/config/src/xcm-configs/bifrostPolkadot.ts
+++ b/packages/config/src/xcm-configs/bifrostPolkadot.ts
@@ -4,17 +4,7 @@ import {
   ExtrinsicBuilder,
   FeeBuilder,
 } from '@moonbeam-network/xcm-builder';
-import {
-  bnc,
-  bncs,
-  fil,
-  glmr,
-  vastr,
-  vdot,
-  vfil,
-  vglmr,
-  vmanta,
-} from '../assets';
+import { bnc, fil, glmr, vastr, vdot, vfil, vglmr, vmanta } from '../assets';
 import { bifrostPolkadot, moonbeam } from '../chains';
 import { ChainRoutes } from '../types/ChainRoutes';
 
@@ -235,35 +225,6 @@ export const bifrostPolkadotRoutes = new ChainRoutes({
       },
       destination: {
         asset: vmanta,
-        chain: moonbeam,
-        balance: BalanceBuilder().evm().erc20(),
-        fee: {
-          amount: FeeBuilder()
-            .xcmPaymentApi()
-            .fromAssetIdQuery({ isAssetReserveChain: false }),
-          asset: bnc,
-        },
-      },
-      extrinsic: ExtrinsicBuilder()
-        .polkadotXcm()
-        .transferAssets()
-        .X1GeneralKey(),
-    },
-    {
-      source: {
-        asset: bncs,
-        balance: BalanceBuilder().substrate().tokens().accounts(),
-        fee: {
-          asset: bnc,
-          balance: BalanceBuilder().substrate().system().account(),
-        },
-        min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
-        destinationFee: {
-          balance: BalanceBuilder().substrate().system().account(),
-        },
-      },
-      destination: {
-        asset: bncs,
         chain: moonbeam,
         balance: BalanceBuilder().evm().erc20(),
         fee: {

--- a/packages/config/src/xcm-configs/moonbeam.ts
+++ b/packages/config/src/xcm-configs/moonbeam.ts
@@ -11,7 +11,6 @@ import {
   astr,
   axlusdc,
   bnc,
-  bncs,
   cfg,
   dai,
   ded,
@@ -1141,32 +1140,6 @@ export const moonbeamRoutes = new ChainRoutes({
           amount: 0.101,
           asset: usdcwh,
         },
-      },
-      contract: ContractBuilder().XcmPrecompile().transferAssetsToPara32(),
-    },
-    {
-      source: {
-        asset: bncs,
-        balance: BalanceBuilder().evm().erc20(),
-        fee: {
-          asset: glmr,
-          balance: BalanceBuilder().substrate().system().account(),
-        },
-        destinationFee: {
-          balance: BalanceBuilder().evm().erc20(),
-        },
-      },
-      destination: {
-        asset: bncs,
-        chain: bifrostPolkadot,
-        balance: BalanceBuilder().substrate().tokens().accounts(),
-        fee: {
-          amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: true,
-          }),
-          asset: bncs,
-        },
-        min: AssetMinBuilder().assetRegistry().currencyMetadatas(),
       },
       contract: ContractBuilder().XcmPrecompile().transferAssetsToPara32(),
     },

--- a/packages/config/src/xcm-configs/moonbeam.ts
+++ b/packages/config/src/xcm-configs/moonbeam.ts
@@ -910,7 +910,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vastr,
         },
@@ -936,7 +936,7 @@ export const moonbeamRoutes = new ChainRoutes({
         chain: bifrostPolkadot,
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vdot,
         },
@@ -962,7 +962,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vfil,
         },
@@ -988,7 +988,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vglmr,
         },
@@ -1014,7 +1014,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vmanta,
         },
@@ -1090,7 +1090,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: fil,
         },
@@ -1162,7 +1162,7 @@ export const moonbeamRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: bncs,
         },

--- a/packages/config/src/xcm-configs/moonriver.ts
+++ b/packages/config/src/xcm-configs/moonriver.ts
@@ -474,7 +474,7 @@ export const moonriverRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vbnc,
         },
@@ -500,7 +500,7 @@ export const moonriverRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vksm,
         },
@@ -526,7 +526,7 @@ export const moonriverRoutes = new ChainRoutes({
         balance: BalanceBuilder().substrate().tokens().accounts(),
         fee: {
           amount: FeeBuilder().xcmPaymentApi().fromCurrencyIdToLocations({
-            isAssetReserveChain: false,
+            isAssetReserveChain: true,
           }),
           asset: vmovr,
         },

--- a/packages/sdk/tests/acceptance/__snapshots__/sdk.test.ts.snap
+++ b/packages/sdk/tests/acceptance/__snapshots__/sdk.test.ts.snap
@@ -512,18 +512,6 @@ exports[`sdk > getParachainBalances > on 'Moonbeam' for address: '0x4E82143Af671
     "symbol": undefined,
   },
   _AssetAmount {
-    "address": "0xfFfffffF6aF229AE7f0F4e0188157e189a487D59",
-    "amount": 0n,
-    "decimals": 12,
-    "ids": {
-      "id": "142155548796783636521833385094843759961",
-    },
-    "key": "bncs",
-    "min": undefined,
-    "originSymbol": "BNCS",
-    "symbol": undefined,
-  },
-  _AssetAmount {
     "address": "0xFFFFfffF71815ab6142E0E20c7259126C6B40612",
     "amount": 0n,
     "decimals": 10,

--- a/packages/sdk/tests/acceptance/__snapshots__/transferData.test.ts.snap
+++ b/packages/sdk/tests/acceptance/__snapshots__/transferData.test.ts.snap
@@ -172,17 +172,6 @@ exports[`sdk/transferData > asset 'laos' from source 'Moonbeam' to destination '
           "originSymbol": "BNC",
           "symbol": undefined,
         },
-        "bncs" => _ChainAsset {
-          "address": "0xfFfffffF6aF229AE7f0F4e0188157e189a487D59",
-          "decimals": 12,
-          "ids": {
-            "id": "142155548796783636521833385094843759961",
-          },
-          "key": "bncs",
-          "min": undefined,
-          "originSymbol": "BNCS",
-          "symbol": undefined,
-        },
         "cfg" => _ChainAsset {
           "address": "0xFFfFfFff44bD9D2FFEE20B25D1Cf9E78Edb6Eae3",
           "decimals": 18,


### PR DESCRIPTION
### Description

For Bifrost VTokens, change the fee calculation indicating that the reserve chain for the assets is Bifrost
What this does is changing the first instruction from `ReserveAssetDeposited` to `WithdrawAsset`. This usually does not have an impact in the weight but for Bifrost it does.

For knowing which instruction is correct, for example, we can check the instructions for [a vASTR transfer](https://moonbeam.subscan.io/xcm_message/polkadot-b8cb10b7bebb0a1ede9d375473ea31b3ce5d160c). We can see that the first instruction is WithdrawAswset

Also, remove BNCS since it is not even registered anymore in Bifrost. `assetRegistry.currencyMetadata` does not yield results for BNCS' currency id


### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
