### PR TITLE
Change extrinsics in Asset Hub configs

### DIFF
--- a/.changeset/chatty-tires-act.md
+++ b/.changeset/chatty-tires-act.md
@@ -1,0 +1,6 @@
+---
+"@moonbeam-network/xcm-builder": patch
+"@moonbeam-network/xcm-config": patch
+---
+
+Change extrinsics from asset hub to stop using transfer_assets and limited_reserve_transfer_assets

--- a/packages/config/src/xcm-configs/alphanetAssetHub.ts
+++ b/packages/config/src/xcm-configs/alphanetAssetHub.ts
@@ -9,9 +9,44 @@ import { tt1, unit } from '../assets';
 import { alphanetAssetHub, moonbaseAlpha } from '../chains';
 import { ChainRoutes } from '../types/ChainRoutes';
 
+const extra = 0.036;
+
 export const alphanetAssetHubRoutes = new ChainRoutes({
   chain: alphanetAssetHub,
   routes: [
+    {
+      source: {
+        asset: unit,
+        balance: BalanceBuilder().substrate().system().account(),
+        fee: {
+          asset: unit,
+          balance: BalanceBuilder().substrate().system().account(),
+          extra,
+        },
+        destinationFee: {
+          balance: BalanceBuilder().substrate().assets().account(),
+        },
+      },
+      destination: {
+        asset: unit,
+        chain: moonbaseAlpha,
+        balance: BalanceBuilder().evm().erc20(),
+        fee: {
+          amount: FeeBuilder()
+            .xcmPaymentApi()
+            .fromHere({ isAssetReserveChain: false }),
+          asset: unit,
+        },
+      },
+      extrinsic: ExtrinsicBuilder()
+        .polkadotXcm()
+        .transferAssetsUsingTypeAndThen()
+        .here(1),
+      monitoring: MonitoringBuilder()
+        .monitorEvent()
+        .polkadotXcm()
+        .messageQueue(),
+    },
     {
       source: {
         asset: tt1,
@@ -33,13 +68,13 @@ export const alphanetAssetHubRoutes = new ChainRoutes({
           amount: FeeBuilder()
             .xcmPaymentApi()
             .fromAssetIdQuery({ isAssetReserveChain: false }),
-          asset: tt1,
+          asset: unit,
         },
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: MonitoringBuilder()
         .monitorEvent()
         .polkadotXcm()

--- a/packages/config/src/xcm-configs/kusamaAssetHub.ts
+++ b/packages/config/src/xcm-configs/kusamaAssetHub.ts
@@ -46,8 +46,8 @@ export const kusamaAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonriver,
     },
     {
@@ -77,8 +77,8 @@ export const kusamaAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonriver,
     },
   ],

--- a/packages/config/src/xcm-configs/polkadotAssetHub.ts
+++ b/packages/config/src/xcm-configs/polkadotAssetHub.ts
@@ -55,7 +55,10 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
           asset: dot,
         },
       },
-      extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssets().here(1),
+      extrinsic: ExtrinsicBuilder()
+        .polkadotXcm()
+        .transferAssetsUsingTypeAndThen()
+        .here(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -85,8 +88,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -116,8 +119,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .limitedReserveTransferAssets()
-        .X2(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -130,9 +133,6 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
           extra,
         },
         min: AssetMinBuilder().assets().asset(),
-        destinationFee: {
-          balance: BalanceBuilder().substrate().assets().account(),
-        },
       },
       destination: {
         asset: pink,
@@ -147,8 +147,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .transferAssets()
-        .X2AndFeeHere(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -161,9 +161,6 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
           extra,
         },
         min: AssetMinBuilder().assets().asset(),
-        destinationFee: {
-          balance: BalanceBuilder().substrate().assets().account(),
-        },
       },
       destination: {
         asset: ded,
@@ -178,8 +175,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .transferAssets()
-        .X2AndFeeHere(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -209,8 +206,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .transferAssets()
-        .X2AndFeeHere(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -240,8 +237,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .transferAssets()
-        .X2AndFeeHere(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {
@@ -271,8 +268,8 @@ export const polkadotAssetHubRoutes = new ChainRoutes({
       },
       extrinsic: ExtrinsicBuilder()
         .polkadotXcm()
-        .transferAssets()
-        .X2AndFeeHere(),
+        .transferAssetsUsingTypeAndThen()
+        .X2(1),
       monitoring: monitoringToMoonbeam,
     },
     {


### PR DESCRIPTION
### Description

- Create new function builders for transfer_assets_using_type_and_then function
- Change configs in Polkadot Asset Hub, Kusama AH and Alphanet AH to use that builder

### Checklist

- [x] If this requires a documentation change, I have created a PR that updates the `mkdocs/docs` directory
- [x] If this requires it, I have updated the Readme
- [x] If necessary, I have updated the examples
- [x] I have verified if I need to create/update unit tests
- [x] I have verified if I need to create/update acceptance tests
- [x] If necessary, I have run acceptance tests on this branch in CI
