### PR TITLE
fix(builder): Xtokens multilocation mis-encodes parachain ids outside 256..4095

### DIFF
--- a/packages/builder/src/contract/contracts/Xtokens/Xtokens.ts
+++ b/packages/builder/src/contract/contracts/Xtokens/Xtokens.ts
@@ -114,7 +114,7 @@ function getDestinationMultilocationForPrecompileDestination(
   return [
     1,
     destination.parachainId
-      ? [`0x0000000${destination.parachainId.toString(16)}`, acc]
+      ? [`0x00${destination.parachainId.toString(16).padStart(8, '0')}`, acc]
       : [acc],
   ];
 }


### PR DESCRIPTION
## Problem

`packages/builder/src/contract/contracts/Xtokens/Xtokens.ts:117` builds the Parachain junction by hand:

```ts
`0x0000000${destination.parachainId.toString(16)}`
```

That is `0x` plus **seven literal zeros** plus the unpadded hex id, so the total width depends on how many hex digits the id happens to have. The junction should be `0x00` followed by a 4-byte id — 10 hex characters:

| parachainId | current | expected | result |
|---|---|---|---|
| 1 | `0x00000001` | `0x0000000001` | one byte short |
| 100 | `0x000000064` | `0x0000000064` | short |
| 888 | `0x0000000378` | `0x0000000378` | correct |
| 2004 | `0x00000007d4` | `0x00000007d4` | correct |
| 4095 | `0x0000000fff` | `0x0000000fff` | correct |
| 4096 | `0x00000001000` | `0x0000001000` | one byte long |
| 65536 | `0x000000010000` | `0x0000010000` | two bytes long |

It is correct only when `toString(16)` yields exactly three digits, i.e. ids in **256..4095**. Every production parachain id in use today falls in that window, which is why nothing is failing right now — but the encoding breaks for anything outside it.

## Fix

Pad explicitly, matching what the rest of the codebase already does:

```ts
`0x00${destination.parachainId.toString(16).padStart(8, '0')}`
```

This is exactly the body of `encodeParachain` in `packages/builder/src/contract/ContractBuilder.utils.ts:169`, which is used in six other places in that file. `Xtokens.ts` is the only site that hand-rolls it.

I inlined the expression rather than importing, because `encodeParachain` is module-private. If you would rather export it and reuse it here, say so and I will switch — that is arguably the better long-term shape, I just did not want to widen the module surface uninvited.

One line changed.